### PR TITLE
Avoid .1 addresses, start router first, and do not ping forever

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,6 @@ ping -c 1 192.168.20.2
 SCRIPT
 
 $pollerStartup = <<SCRIPT
-route
 route del default
 route add default gateway 192.168.10.2
 ping -c 1 192.168.10.2
@@ -41,7 +40,6 @@ apt-get install -y snmp
 SCRIPT
 
 $serverStartup = <<SCRIPT
-route
 route del default
 route add default gateway 192.168.20.2
 ping -c 1 192.168.20.2

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,19 +61,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     router.vm.network "private_network", ip: "192.168.20.2"
     # router.vm.network "forwarded_port", guest: 3000, host: 4000
     router.vm.hostname = "router"
-    router.vm.provision "shell", inline: $routerStartup
+    router.vm.provision "shell", inline: $routerStartup, run: "always"
   end
 
   config.vm.define "server" do |server|
     server.vm.network "private_network", ip: "192.168.20.3"
     server.vm.hostname = "server"
-    server.vm.provision "shell", inline: $serverStartup
+    server.vm.provision "shell", inline: $serverStartup, run: "always"
   end
 
   config.vm.define "poller" do |poller|
     poller.vm.network "private_network", ip: "192.168.10.3"
     poller.vm.hostname = "poller"
-    poller.vm.provision "shell", inline: $pollerStartup
+    poller.vm.provision "shell", inline: $pollerStartup, run: "always"
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,20 +27,24 @@ update-rc.d redis-server defaults
 /etc/init.d/redis-server start
 #
 # ping the endpoints to activate the network
-ping 192.168.10.2
-ping 192.168.20.2
+ping -c 1 192.168.10.2
+ping -c 1 192.168.20.2
 SCRIPT
 
 $pollerStartup = <<SCRIPT
+route
 route del default
-route add default gateway 192.168.10.1
+route add default gateway 192.168.10.2
+ping -c 1 192.168.10.2
 apt-get update
 apt-get install -y snmp
 SCRIPT
 
 $serverStartup = <<SCRIPT
+route
 route del default
-route add default gateway 192.168.20.1
+route add default gateway 192.168.20.2
+ping -c 1 192.168.20.2
 apt-get update
 apt-get install -y snmpd
 mv /etc/snmp/snmpd.conf /etc/snmp/snmpd.orig
@@ -52,26 +56,26 @@ SCRIPT
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
 
-  config.vm.define "poller" do |poller|
-    poller.vm.network "private_network", ip: "192.168.10.2"
-    poller.vm.hostname = "poller"
-    poller.vm.provision "shell", inline: $pollerStartup
+  config.vm.define "router" do |router|
+    router.vm.network "private_network", type: "dhcp", use_dhcp_assigned_default_route: true
+    # router.vm.network "public_network", bridge: "en0: Wi-Fi (AirPort)"
+    router.vm.network "private_network", ip: "192.168.10.2"
+    router.vm.network "private_network", ip: "192.168.20.2"
+    # router.vm.network "forwarded_port", guest: 3000, host: 4000
+    router.vm.hostname = "router"
+    router.vm.provision "shell", inline: $routerStartup
   end
 
   config.vm.define "server" do |server|
-    server.vm.network "private_network", ip: "192.168.20.2"
+    server.vm.network "private_network", ip: "192.168.20.3"
     server.vm.hostname = "server"
     server.vm.provision "shell", inline: $serverStartup
   end
 
-  config.vm.define "router" do |router|
-    router.vm.network "private_network", type: "dhcp", use_dhcp_assigned_default_route: true
-    # router.vm.network "public_network", bridge: "en0: Wi-Fi (AirPort)"
-    router.vm.network "private_network", ip: "192.168.10.1"
-    router.vm.network "private_network", ip: "192.168.20.1"
-    # router.vm.network "forwarded_port", guest: 3000, host: 4000
-    router.vm.hostname = "router"
-    router.vm.provision "shell", inline: $routerStartup
+  config.vm.define "poller" do |poller|
+    poller.vm.network "private_network", ip: "192.168.10.3"
+    poller.vm.hostname = "poller"
+    poller.vm.provision "shell", inline: $pollerStartup
   end
 
 end

--- a/readme.md
+++ b/readme.md
@@ -58,5 +58,8 @@ node app.js
 ```bash
 # terminal 2
 vagrant ssh poller
-snmpget -v2c -c public 192.168.20.2 1.3.6.1.2.1.1.1.0 -r 0
+snmpget -v2c -c public 192.168.20.3 1.3.6.1.2.1.1.3.0 -r 0
 ```
+
+Running the snmpget command multiple times should see the Timeticks
+cached for 30 seconds.


### PR DESCRIPTION
I went looking for an SNMP cache and the design of your system looked ideal for me.  I have a [single server](http://wlcg-squid-monitor.cern.ch) that sends lots of duplicate SNMP queries (from various MRTG plots) to squids distributed all over the world, and I wanted to see if I could eliminate the duplicates.  Because all of the queries are on a single machine, it seems reasonable to use iptables to redirect them to an application running on the same machine, which I think I could do with leonidas.

However, in order to learn about it, I wanted to start with your Vagrantfile.  My host was Scientific Linux 6 (basically the same as Centos6 & RHEL6) with vagrant-2.0.1-1.x86_64 and VirtualBox-5.2-5.2.6_120293_el6-1.x86_64.

I had quite a bit of trouble with getting the networking working in the server & poller.  First I noticed that even though they depend on the router, they aren't started until after the router.  So I changed the ordering to start the router first.  

Next, there were pings at the end of the router script trying to connect to the server & poller.  Now that I changed the order, that was no good, and besides, ping runs forever by default.  I left the pings in but changed them to just ping the router's own interfaces and added a '-c 1' option so they only send one packet.

That still didn't fix the network in the server & poller, however.  I noticed that there were a number of yellow warnings like this one

```
==> router: You assigned a static IP ending in ".1" to this machine.
==> router: This is very often used by the router and can cause the
==> router: network to not work properly. If the network doesn't work
==> router: properly, try changing this IP.
==> router: You assigned a static IP ending in ".1" to this machine.
==> router: This is very often used by the router and can cause the
==> router: network to not work properly. If the network doesn't work
==> router: properly, try changing this IP.
```

I also noticed vboxnet[01] interfaces on the host machine with 192.168.[12]0.1 interfaces and I think they were interfering with the interfaces inside of the virtual machine.  So I added one to all of the IP addresses, so the router has .2 and the poller & server have .3.

Now with the changes in this PR, I can finally get all 3 VMs started without errors.  I'm still having trouble running leonidas, but I'll put that in a separate issue.